### PR TITLE
Append summary even if there is already one

### DIFF
--- a/ProveIt_Wikipedia.js
+++ b/ProveIt_Wikipedia.js
@@ -23,6 +23,13 @@ var proveit = $.extend({
 
 	TEMPLATE_REFERENCE_ICON: '//upload.wikimedia.org/wikipedia/commons/d/dd/Silk-Page_white.png',
 
+
+	/**
+	 * Keep track of whether we have already added ProveIt to the summary.
+	 * @type boolean
+	 */
+	summaryAdded: false,
+
 	/**
 	 * Convenience function that returns the message for the given key.
 	 *
@@ -328,19 +335,20 @@ var proveit = $.extend({
 		return reference;
 	},
 
-	// XXX: Add back old behavior; this is not meant to be the only summary.
 	/**
 	 * Adds the ProveIt edit summary to the edit summary field.
 	 *
 	 * @return {void}
 	 */
 	addSummary: function () {
-		var summary = $( '#wpSummary' ).val();
-		if ( summary ) {
-			return; // If there is already a summary, don't screw it up
+		if ( this.summaryAdded ) {
+			return;
 		}
-		summary = proveit.getMessage( 'summary' );
+
+		var summary = $( '#wpSummary' ).val();
+		summary = summary + proveit.getMessage( 'summary' );
 		$( '#wpSummary' ).val( summary );
+		this.summaryAdded = true;
 	},
 
 	/**

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -546,7 +546,7 @@ proveit.messages = {
 	'add-custom-param-button': 'Add custom parameter',
 	'show-all-params-button': 'Show all the parameters',
 	'no-references': 'No references found',
-	'summary': 'Edited with ProveIt'
+	'summary': ' (edited with [[User:ProveIt_GT|ProveIt]])'
 };
 
 proveit.icons = {


### PR DESCRIPTION
This puts back a simpler version of the summary logic before.  Like before, it adds it regardless of whether there is already a summary.  However, unlike before, it adds it immediately, rather than on-submit.

This also doesn't reinstate the user setting that used to be there.  That used to a work in a somewhat tricky way using a field on the proveit global.

I'm hoping that adding it immediately (so the user has a chance to customize it) will mean people won't need the preference.  If they want it back, we should look at a nicer way to do this.  Basically, I think if we want settings, we should implement a settings pane, and save the settings to the user account.  I know how to do the second part, and the first just takes some thought about user experience.